### PR TITLE
增加geetest_params,用于填写人机验证api需要传入的参数

### DIFF
--- a/src/nonebot_plugin_mystool/plugin_data.py
+++ b/src/nonebot_plugin_mystool/plugin_data.py
@@ -89,6 +89,8 @@ class Preference(BaseSettings, extra=Extra.ignore):
     '''每次检查原神便笺间隔，单位为分钟'''
     geetest_url: Optional[str]
     '''极验Geetest人机验证打码接口URL'''
+    geetest_params: Optional[Dict[str, Any]] = None
+    '''极验Geetest人机验证打码API发送的参数（除gt，challenge外）'''
     geetest_json: Optional[Dict[str, Any]] = {
         "gt": "{gt}",
         "challenge": "{challenge}"

--- a/src/nonebot_plugin_mystool/utils.py
+++ b/src/nonebot_plugin_mystool/utils.py
@@ -233,7 +233,11 @@ async def get_validate(gt: str = None, challenge: str = None, retry: bool = True
     """
     if not (gt and challenge) or not _conf.preference.geetest_url:
         return GeetestResult("", "")
-    url = _conf.preference.geetest_url.format(gt=gt, challenge=challenge)
+    geetest_params = _conf.preference.geetest_params
+    print(f'params:{geetest_params}')
+    url_params = "&".join([f"{key}={value}" for key, value in geetest_params.items() if key not in ("gt", "challenge")])
+    url = f"{_conf.preference.geetest_url}&{url_params}&gt={gt}&challenge={challenge}"
+    print(f'url:{url}')
     content = _conf.preference.geetest_json or Preference().geetest_json
     for key, value in content.items():
         if isinstance(value, str):
@@ -245,6 +249,7 @@ async def get_validate(gt: str = None, challenge: str = None, retry: bool = True
                 async with httpx.AsyncClient() as client:
                     res = await client.post(url, timeout=60, json=content)
                 geetest_data = res.json()
+                print(f'vaildate:{geetest_data}')
                 validate = geetest_data['data']['validate']
                 seccode = geetest_data['data'].get('seccode') or f"{validate}|jordan"
                 return GeetestResult(validate=validate, seccode=seccode)

--- a/src/nonebot_plugin_mystool/utils.py
+++ b/src/nonebot_plugin_mystool/utils.py
@@ -234,7 +234,7 @@ async def get_validate(gt: str = None, challenge: str = None, retry: bool = True
     if not (gt and challenge) or not _conf.preference.geetest_url:
         return GeetestResult("", "")
     geetest_params = _conf.preference.geetest_params
-    print(f'params:{geetest_params}')
+    logger.info(f'params:{geetest_params}')
     url_params = "&".join([f"{key}={value}" for key, value in geetest_params.items() if key not in ("gt", "challenge")])
     url = f"{_conf.preference.geetest_url}&{url_params}&gt={gt}&challenge={challenge}"
     content = _conf.preference.geetest_json or Preference().geetest_json

--- a/src/nonebot_plugin_mystool/utils.py
+++ b/src/nonebot_plugin_mystool/utils.py
@@ -233,7 +233,8 @@ async def get_validate(gt: str = None, challenge: str = None, retry: bool = True
     """
     if not (gt and challenge) or not _conf.preference.geetest_url:
         return GeetestResult("", "")
-    params = {"gt": gt, "challenge": challenge}.update(_conf.preference.geetest_params)
+    params = {"gt": gt, "challenge": challenge}
+    params.update(_conf.preference.geetest_params)
     content = _conf.preference.geetest_json or Preference.geetest_json
     for key, value in content.items():
         if isinstance(value, str):

--- a/src/nonebot_plugin_mystool/utils.py
+++ b/src/nonebot_plugin_mystool/utils.py
@@ -237,7 +237,6 @@ async def get_validate(gt: str = None, challenge: str = None, retry: bool = True
     print(f'params:{geetest_params}')
     url_params = "&".join([f"{key}={value}" for key, value in geetest_params.items() if key not in ("gt", "challenge")])
     url = f"{_conf.preference.geetest_url}&{url_params}&gt={gt}&challenge={challenge}"
-    print(f'url:{url}')
     content = _conf.preference.geetest_json or Preference().geetest_json
     for key, value in content.items():
         if isinstance(value, str):
@@ -249,7 +248,6 @@ async def get_validate(gt: str = None, challenge: str = None, retry: bool = True
                 async with httpx.AsyncClient() as client:
                     res = await client.post(url, timeout=60, json=content)
                 geetest_data = res.json()
-                print(f'vaildate:{geetest_data}')
                 validate = geetest_data['data']['validate']
                 seccode = geetest_data['data'].get('seccode') or f"{validate}|jordan"
                 return GeetestResult(validate=validate, seccode=seccode)


### PR DESCRIPTION
geetest_params或许可以跟geetest_json合并，但是不太懂
添加geetest_params主要是减少改动源码的可能性，尽量在data.json上作改动
同时保持`geetest_url`的简洁，基本结构是：api+密钥