### PR TITLE
尝试优化签到、任务的私聊和群聊中构建推送消息的代码结构

### DIFF
--- a/src/nonebot_plugin_mystool/command/plan.py
+++ b/src/nonebot_plugin_mystool/command/plan.py
@@ -342,7 +342,7 @@ async def perform_game_sign(
             await asyncio.sleep(plugin_config.preference.sleep_time)
         
         if isinstance(event, OneBotV11GroupMessageEvent):   #在群聊触发游戏签到将使用合并消息
-            await qqgroup_msg(bot, event, msgs_list)
+            await send_qqGroup(bot, event, msgs_list)
         else:
             for msg in msgs_list:
                 await matcher.send(msg)
@@ -502,7 +502,7 @@ async def perform_bbs_sign(
                     await send_private_msg(user_id=user_id, message=msg)
         
         if isinstance(event, OneBotV11GroupMessageEvent):   #在群聊触发游戏签到将使用合并消息
-            await qqgroup_msg(bot, event, msgs_list)
+            await send_qqGroup(bot, event, msgs_list)
         else:
             for msg in msgs_list:
                 await matcher.send(msg)
@@ -772,7 +772,7 @@ async def weibo_code_check(user: UserData, user_ids: Iterable[str], mode=0, matc
             await matcher.send(message)
 
 
-async def qqgroup_msg(bot, event, msgs_list):
+async def send_qqGroup(bot, event, msgs_list):
     def build_forward_msg(msg):
         #受限于LLOnebot，合并转发消息只能使用bot的身份无法自定义
         return {"type": "node", "data": {"nickname": "流萤", "user_id": "114514", "content": msg}}  

--- a/src/nonebot_plugin_mystool/command/plan.py
+++ b/src/nonebot_plugin_mystool/command/plan.py
@@ -50,10 +50,10 @@ async def _(bot:Bot, event: Union[GeneralMessageEvent], matcher: Matcher, comman
     手动游戏签到函数
     """
     user_id = event.get_user_id()
-    logger.info(f'event:{type(event)}|{event}')
+    msgs_list = []
     user = PluginDataManager.plugin_data.users.get(user_id)
     if not user or not user.accounts:
-        await manually_game_sign.finish(f"⚠️你尚未绑定米游社账户，请先使用『{COMMAND_BEGIN}登录』进行登录")
+        await manually_game_sign.finish(f"⚠️你尚未绑定米游社账户，请先使用『{COMMAND_BEGIN}登录』进行登录", at_sender=True)
     if command_arg:
         if (specified_user_id := str(command_arg)) == "*" or specified_user_id.isdigit():
             if user_id not in read_admin_list():
@@ -62,7 +62,7 @@ async def _(bot:Bot, event: Union[GeneralMessageEvent], matcher: Matcher, comman
                 if specified_user_id == "*":
                     await manually_game_sign.send("⏳开始为所有用户执行游戏签到...")
                     for user_id_, user_ in get_unique_users():
-                        await manually_game_sign.send(f"⏳开始为用户 {user_id_} 执行游戏签到...")
+                        await msgs_list.append(f"⏳开始为用户 {user_id_} 执行游戏签到...")
                         await perform_game_sign(
                             bot=bot,
                             user=user_,
@@ -73,8 +73,8 @@ async def _(bot:Bot, event: Union[GeneralMessageEvent], matcher: Matcher, comman
                 else:
                     specified_user = PluginDataManager.plugin_data.users.get(specified_user_id)
                     if not specified_user:
-                        await manually_game_sign.finish(f"⚠️未找到用户 {specified_user_id}")
-                    await manually_game_sign.send(f"⏳开始为用户 {specified_user_id} 执行游戏签到...")
+                        await manually_game_sign.finish(f"⚠️未找到用户 {specified_user_id}", at_sender=True)
+                    await msgs_list.append(f"⏳开始为用户 {specified_user_id} 执行游戏签到...")
                     await perform_game_sign(
                         bot=bot,
                         user=specified_user,
@@ -83,8 +83,8 @@ async def _(bot:Bot, event: Union[GeneralMessageEvent], matcher: Matcher, comman
                         event=event
                     )
     else:
-        await manually_game_sign.send("⏳开始游戏签到...")
-        await perform_game_sign(bot=bot, user=user, user_ids=[user_id], matcher=matcher, event=event)
+        msgs_list.append("⏳开始游戏签到...")
+        await perform_game_sign(bot=bot, user=user, user_ids=[user_id], matcher=matcher, event=event, msgs_list=msgs_list)
 
 
 manually_bbs_sign = on_command(plugin_config.preference.command_start + '任务', priority=5, block=True)


### PR DESCRIPTION
游戏和任务的中大部分消息推送写入列表中，到最后根据event类型区分私聊和群聊。
私聊在各自函数内通过遍历进行matcher发送，
群聊引用新增`send_qqGroup`函数进行构建合并消息推送
